### PR TITLE
Several new params

### DIFF
--- a/src/main/java/org/camunda/community/benchmarks/FixedBackoffSupplier.java
+++ b/src/main/java/org/camunda/community/benchmarks/FixedBackoffSupplier.java
@@ -1,0 +1,17 @@
+package org.camunda.community.benchmarks;
+
+import io.camunda.zeebe.client.api.worker.BackoffSupplier;
+
+public class FixedBackoffSupplier implements BackoffSupplier {
+
+    private long fixedBackOffDelay = 0;
+
+    public FixedBackoffSupplier(long fixedBackOffDelay) {
+        this.fixedBackOffDelay = fixedBackOffDelay;
+    }
+
+    @Override
+    public long supplyRetryDelay(long currentRetryDelay) {
+        return fixedBackOffDelay;
+    }
+}

--- a/src/main/java/org/camunda/community/benchmarks/JobWorker.java
+++ b/src/main/java/org/camunda/community/benchmarks/JobWorker.java
@@ -1,25 +1,20 @@
 package org.camunda.community.benchmarks;
 
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
-import io.camunda.zeebe.spring.client.annotation.ZeebeWorker;
 import io.camunda.zeebe.spring.client.exception.ZeebeBpmnError;
 import io.camunda.zeebe.spring.client.jobhandling.CommandWrapper;
-import io.camunda.zeebe.spring.client.jobhandling.JobHandlerInvokingSpringBeans;
 import org.camunda.community.benchmarks.config.BenchmarkConfiguration;
 import org.camunda.community.benchmarks.refactoring.RefactoredCommandWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-import java.time.Duration;
 import java.time.Instant;
 
 @Component
@@ -61,26 +56,31 @@ public class JobWorker {
     public void startWorkers() {
         String taskType = config.getJobType();
 
+        boolean startWorkers = config.isStartWorkers();
         int numberOfJobTypes = config.getMultipleJobTypes();
 
-        if(numberOfJobTypes <= 0) {
+        if(startWorkers) {
 
-            // worker for normal task type
-            registerWorker(taskType);
+            if (numberOfJobTypes <= 0) {
 
-            // worker for normal "task-type-{starterId}"
-            registerWorker(taskType + "-" + config.getStarterId());
+                // worker for normal task type
+                registerWorker(taskType);
 
-            // worker marking completion of process instance via "task-type-complete"
-            registerWorker(taskType + "-completed");
+                // worker for normal "task-type-{starterId}"
+                registerWorker(taskType + "-" + config.getStarterId());
 
-            // worker marking completion of process instance via "task-type-complete"
-            registerWorker(taskType + "-" + config.getStarterId() + "-completed");
+                // worker marking completion of process instance via "task-type-complete"
+                registerWorker(taskType + "-completed");
 
-        } else {
+                // worker marking completion of process instance via "task-type-complete"
+                registerWorker(taskType + "-" + config.getStarterId() + "-completed");
 
-            for(int i=0; i<numberOfJobTypes; i++) {
-                registerWorker(taskType + "-" + (i+1));
+            } else {
+
+                for (int i = 0; i < numberOfJobTypes; i++) {
+                    registerWorker(taskType + "-" + (i + 1));
+                }
+
             }
 
         }

--- a/src/main/java/org/camunda/community/benchmarks/JobWorker.java
+++ b/src/main/java/org/camunda/community/benchmarks/JobWorker.java
@@ -46,11 +46,23 @@ public class JobWorker {
     public void startWorkers() {
         String taskType = config.getJobType();
 
-        // worker for normal task type
-        client.newWorker()
-                .jobType(taskType)
-                .handler(new SimpleDelayCompletionHandler(false))
-                .open();
+        Integer numberOfJobTypes = config.getMultipleJobTypes();
+        if(numberOfJobTypes <= 0) {
+            // worker for normal task type
+            client.newWorker()
+                    .jobType(taskType)
+                    .handler(new SimpleDelayCompletionHandler(false))
+                    .open();
+        } else {
+            for(int i=0; i<numberOfJobTypes; i++) {
+                client.newWorker()
+                        .jobType(taskType + "-" + (i+1))
+                        .handler(new SimpleDelayCompletionHandler(false))
+                        .open();
+            }
+        }
+
+        /*
         // worker for normal "task-type-{starterId}"
         client.newWorker()
                 .jobType(taskType + "-" + config.getStarterId())
@@ -66,6 +78,7 @@ public class JobWorker {
                 .jobType(taskType + "-" + config.getStarterId() + "-completed")
                 .handler(new SimpleDelayCompletionHandler(true))
                 .open();
+                */
     }
 
     public class SimpleDelayCompletionHandler implements JobHandler {

--- a/src/main/java/org/camunda/community/benchmarks/JobWorker.java
+++ b/src/main/java/org/camunda/community/benchmarks/JobWorker.java
@@ -48,37 +48,39 @@ public class JobWorker {
 
         Integer numberOfJobTypes = config.getMultipleJobTypes();
         if(numberOfJobTypes <= 0) {
+
             // worker for normal task type
             client.newWorker()
                     .jobType(taskType)
                     .handler(new SimpleDelayCompletionHandler(false))
                     .open();
+            // worker for normal "task-type-{starterId}"
+            client.newWorker()
+                    .jobType(taskType + "-" + config.getStarterId())
+                    .handler(new SimpleDelayCompletionHandler(false))
+                    .open();
+            // worker marking completion of process instance via "task-type-complete"
+            client.newWorker()
+                    .jobType(taskType + "-completed")
+                    .handler(new SimpleDelayCompletionHandler(true))
+                    .open();
+            // worker marking completion of process instance via "task-type-complete"
+            client.newWorker()
+                    .jobType(taskType + "-" + config.getStarterId() + "-completed")
+                    .handler(new SimpleDelayCompletionHandler(true))
+                    .open();
+
         } else {
+
             for(int i=0; i<numberOfJobTypes; i++) {
                 client.newWorker()
                         .jobType(taskType + "-" + (i+1))
                         .handler(new SimpleDelayCompletionHandler(false))
                         .open();
             }
+
         }
 
-        /*
-        // worker for normal "task-type-{starterId}"
-        client.newWorker()
-                .jobType(taskType + "-" + config.getStarterId())
-                .handler(new SimpleDelayCompletionHandler(false))
-                .open();
-        // worker marking completion of process instance via "task-type-complete"
-        client.newWorker()
-                .jobType(taskType + "-completed")
-                .handler(new SimpleDelayCompletionHandler(true))
-                .open();
-        // worker marking completion of process instance via "task-type-complete"
-        client.newWorker()
-                .jobType(taskType + "-" + config.getStarterId() + "-completed")
-                .handler(new SimpleDelayCompletionHandler(true))
-                .open();
-                */
     }
 
     public class SimpleDelayCompletionHandler implements JobHandler {

--- a/src/main/java/org/camunda/community/benchmarks/config/BenchmarkConfiguration.java
+++ b/src/main/java/org/camunda/community/benchmarks/config/BenchmarkConfiguration.java
@@ -30,6 +30,8 @@ public class BenchmarkConfiguration {
 
     private int taskPiRatio;
 
+    private long fixedBackOffDelay = 0;
+
     public String getStartRateAdjustmentStrategy() {
         return startRateAdjustmentStrategy;
     }
@@ -149,5 +151,13 @@ public class BenchmarkConfiguration {
 
     public void setStarterId(String starterId) {
         this.starterId = starterId;
+    }
+
+    public long getFixedBackOffDelay() {
+        return fixedBackOffDelay;
+    }
+
+    public void setFixedBackOffDelay(long fixedBackOffDelay) {
+        this.fixedBackOffDelay = fixedBackOffDelay;
     }
 }

--- a/src/main/java/org/camunda/community/benchmarks/config/BenchmarkConfiguration.java
+++ b/src/main/java/org/camunda/community/benchmarks/config/BenchmarkConfiguration.java
@@ -4,8 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 
-import java.util.concurrent.TimeUnit;
-
 @Configuration
 @ConfigurationProperties(prefix = "benchmark")
 public class BenchmarkConfiguration {
@@ -15,6 +13,7 @@ public class BenchmarkConfiguration {
     private long startPiPerSecond = 500;
     private String jobType = "benchmark-task";
     private int multipleJobTypes = 0;
+    private boolean startWorkers = true;
     private long taskCompletionDelay = 200;
     private String bpmnProcessId = "benchmark";
     private String payloadPath = "bpmn/typical_payload.json";
@@ -87,6 +86,14 @@ public class BenchmarkConfiguration {
 
     public void setMultipleJobTypes(int multipleJobTypes) {
         this.multipleJobTypes = multipleJobTypes;
+    }
+
+    public boolean isStartWorkers() {
+        return startWorkers;
+    }
+
+    public void setStartWorkers(boolean startWorkers) {
+        this.startWorkers = startWorkers;
     }
 
     public long getStartPiPerSecond() {

--- a/src/main/java/org/camunda/community/benchmarks/config/BenchmarkConfiguration.java
+++ b/src/main/java/org/camunda/community/benchmarks/config/BenchmarkConfiguration.java
@@ -14,6 +14,7 @@ public class BenchmarkConfiguration {
 
     private long startPiPerSecond = 500;
     private String jobType = "benchmark-task";
+    private int multipleJobTypes = 0;
     private long taskCompletionDelay = 200;
     private String bpmnProcessId = "benchmark";
     private String payloadPath = "bpmn/typical_payload.json";
@@ -76,6 +77,14 @@ public class BenchmarkConfiguration {
 
     public void setJobType(String jobType) {
         this.jobType = jobType;
+    }
+
+    public int getMultipleJobTypes() {
+        return multipleJobTypes;
+    }
+
+    public void setMultipleJobTypes(int multipleJobTypes) {
+        this.multipleJobTypes = multipleJobTypes;
     }
 
     public long getStartPiPerSecond() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,10 @@ benchmark.startPiPerSecond=25
 benchmark.taskCompletionDelay=200
 benchmark.bpmnProcessId=benchmark
 benchmark.jobType=benchmark-task
+# Create multiple workers to respond to multiple job types
+# By default, only one worker is created and will listen for job type defined above.
+# If the value is set to `2`, for example, 2 workers are created: `benchmark-task-1` and `benchmark-task-2`
+benchmark.multipleJobTypes=0
 # 5 minutes warmup:  5*60*1000
 benchmark.warmupPhaseDurationMillis=300000
 # can be "none" or "backpressure" or "jobRatio"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,3 +50,6 @@ async.maxPoolSize=100
 async.queueCapacity=1000
 
 scheduler.poolSize=10
+
+# when 0, use the default Exponential Backoff Supplier. Otherwise, specify fixed number of millis backoff.
+benchmark.fixedBackOffDelay=0

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,8 @@ management.endpoints.web.exposure.include=*
 benchmark.startPiPerSecond=25
 benchmark.taskCompletionDelay=200
 benchmark.bpmnProcessId=benchmark
+# Set this to false if you only want to start processes but don't want any workers
+benchmark.startWorkers=true
 benchmark.jobType=benchmark-task
 # Create multiple workers to respond to multiple job types
 # By default, only one worker is created and will listen for job type defined above.


### PR DESCRIPTION
This pull request adds support for 3 new parameters: 

1. `benchmark.multipleJobTypes`. Only one job type, `benchmark-task` is used when set to 0. Otherwise, this starts workers for multiple job types. For example, if set to 2, will start workers for `benchmark-test-1` and `benchmark-test-2`
2. `benchmark.fixedBackOffDelay`. When set to 0, will default to Exponential Backoff Delay. Otherwise, specify fixed number of millis backoff
3. set `benchmark.startWorkers=false` if you only want to start instances, but not start any workers