### PR TITLE
Fix JobWorker crash when bpmnResource includes a DMN file

### DIFF
--- a/src/main/java/org/camunda/community/benchmarks/utils/BpmnJobTypeParser.java
+++ b/src/main/java/org/camunda/community/benchmarks/utils/BpmnJobTypeParser.java
@@ -42,14 +42,19 @@ public class BpmnJobTypeParser {
 
         for (Resource resource : bpmnResources) {
             if (resource != null && resource.exists()) {
+                String filename = resource.getFilename();
+                if (filename == null || !filename.toLowerCase().endsWith(".bpmn")) {
+                    LOG.debug("Skipping non-BPMN resource {} for job type extraction", filename);
+                    continue;
+                }
                 try {
                     Set<String> resourceJobTypes = extractJobTypesFromResource(resource);
                     jobTypes.addAll(resourceJobTypes);
-                    LOG.info("Extracted {} job types from {}: {}", 
-                        resourceJobTypes.size(), resource.getFilename(), resourceJobTypes);
-                } catch (IOException e) {
-                    LOG.error("Failed to extract job types from resource {}: {}", 
-                        resource.getFilename(), e.getMessage(), e);
+                    LOG.info("Extracted {} job types from {}: {}",
+                        resourceJobTypes.size(), filename, resourceJobTypes);
+                } catch (Exception e) {
+                    LOG.error("Failed to extract job types from resource {}: {}",
+                        filename, e.getMessage(), e);
                 }
             }
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,16 +22,15 @@
 #camunda.client.auth.client-secret=XXX
 #camunda.client.identity.base-url=https://custom.domain/identity
 
-camunda.client.auth.method=none
 camunda.client.mode=self-managed
-camunda.client.rest-address=http://0.0.0.0:8081
-camunda.client.grpc-address=http://localhost:26500
+camunda.client.zeebe.base-url=http://localhost:26500
+camunda.client.zeebe.grpc-address=http://localhost:26500
 #camunda.client.zeebe.rest-address=http://camunda-zeebe-gateway:8080
-camunda.client.prefer-rest-over-grpc=false
+camunda.client.zeebe.prefer-rest-over-grpc=false
 
 server.port=8088
 management.endpoints.web.exposure.include=*
-management.prometheus.metrics.export.enabled=true
+management.metrics.export.prometheus.enabled=true
 
 # Main benchmark configurations
 ######################
@@ -77,9 +76,9 @@ benchmark.starterId=benchmarkStarter1
 
 # More specific configs you better leave as is unless you know what you are doing :-)
 ######################
-camunda.client.worker.defaults.max-jobs-active=2000
-camunda.client.execution-threads=100
-camunda.client.worker.defaults.stream-enabled=true
+camunda.client.zeebe.defaults.max-jobs-active=2000
+camunda.client.zeebe.execution-threads=100
+camunda.client.zeebe.defaults.stream-enabled=true
 # camunda.client.zeebe.defaults.request-timeout=30s
 
 benchmark.maxBackpressurePercentage=10.0

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,15 +22,16 @@
 #camunda.client.auth.client-secret=XXX
 #camunda.client.identity.base-url=https://custom.domain/identity
 
+camunda.client.auth.method=none
 camunda.client.mode=self-managed
-camunda.client.zeebe.base-url=http://localhost:26500 
-camunda.client.zeebe.grpc-address=http://localhost:26500
+camunda.client.rest-address=http://0.0.0.0:8081
+camunda.client.grpc-address=http://localhost:26500
 #camunda.client.zeebe.rest-address=http://camunda-zeebe-gateway:8080
-camunda.client.zeebe.prefer-rest-over-grpc=false
+camunda.client.prefer-rest-over-grpc=false
 
 server.port=8088
 management.endpoints.web.exposure.include=*
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
 
 # Main benchmark configurations
 ######################
@@ -76,9 +77,9 @@ benchmark.starterId=benchmarkStarter1
 
 # More specific configs you better leave as is unless you know what you are doing :-)
 ######################
-camunda.client.zeebe.defaults.max-jobs-active=2000
-camunda.client.zeebe.execution-threads=100
-camunda.client.zeebe.defaults.stream-enabled=true
+camunda.client.worker.defaults.max-jobs-active=2000
+camunda.client.execution-threads=100
+camunda.client.worker.defaults.stream-enabled=true
 # camunda.client.zeebe.defaults.request-timeout=30s
 
 benchmark.maxBackpressurePercentage=10.0


### PR DESCRIPTION
`benchmark.bpmnResource `can list both `BPMN` and `DMN` resources for ProcessDeployer to deploy together, but `JobWorker.startWorkers()` fed that same array into `BpmnJobTypeParser`, which always parses via the Zeebe BPMN model API. A configured .dmn file (e.g. complex_decision.dmn) doesn't match the BPMN schema, so `Bpmn.readModelFromStream threw a ModelParseException/SAXException` that crashed startup before workers could register.

BpmnJobTypeParser now skips non-.bpmn resources and catches Exception (not just IOException) around per-resource parsing, so an unexpected resource is logged and skipped instead of taking down the app.


**How to reproduce (before this fix)**

Check out the base commit (before this PR) on main.

Run the app:

`mvn spring-boot:run`
Startup crashes before workers register, with:

```
Exception in thread "main" org.camunda.bpm.model.xml.ModelParseException: SAXException while parsing input stream
    at ...DomUtil.parseInputStream(DomUtil.java:245)
    at ...AbstractModelParser.parseModelFromStream(AbstractModelParser.java:131)
    at io.camunda.zeebe.model.bpmn.impl.BpmnParser.parseModelFromStream(BpmnParser.java:62)
    at io.camunda.zeebe.model.bpmn.Bpmn.readModelFromStream(Bpmn.java:309)
    at org.camunda.community.benchmarks.utils.BpmnJobTypeParser.extractJobTypesFromResource(BpmnJobTypeParser.java:70)
    at org.camunda.community.benchmarks.utils.BpmnJobTypeParser.extractJobTypes(BpmnJobTypeParser.java:46)
    at org.camunda.community.benchmarks.JobWorker.startWorkers(JobWorker.java:92)
    at org.camunda.community.benchmarks.BenchmarkApplication.main(BenchmarkApplication.java:20)
```
Root cause: `JobWorker.startWorkers() `passes the entire `benchmark.bpmnResource` array — including any .dmn entries meant only for ProcessDeployer — into BpmnJobTypeParser, which always parses with the Zeebe BPMN model API. DMN XML doesn't match the BPMN schema, so parsing throws an unchecked ModelParseException that isn't caught, crashing the whole app at startup.

After this fix: the same config starts up cleanly — BpmnJobTypeParser skips any resource that isn't a .bpmn file, and wraps per-resource parsing in a broader catch (Exception e) so a future malformed/unexpected resource is logged and skipped instead of taking down the app.